### PR TITLE
A small addition to updated unavaliable values

### DIFF
--- a/iso22133.c
+++ b/iso22133.c
@@ -2758,9 +2758,9 @@ ssize_t encodeMONRMessage(const struct timeval *objectTime, const CartesianPosit
 	MONRData.gpsQmsOfWeek =
 		GPSQmsOfWeek >= 0 ? (uint32_t) GPSQmsOfWeek : GPS_SECOND_OF_WEEK_UNAVAILABLE_VALUE;
 	if (position.isPositionValid) {
-		position.isXcoordValid ? MONRData.xPosition = (int32_t) (position.xCoord_m * POSITION_ONE_METER_VALUE) : POSITION_UNAVAILABLE_VALUE;
-		position.isYcoordValid ? MONRData.yPosition = (int32_t) (position.yCoord_m * POSITION_ONE_METER_VALUE) : POSITION_UNAVAILABLE_VALUE;
-		position.isZcoordValid ? MONRData.zPosition = (int32_t) (position.zCoord_m * POSITION_ONE_METER_VALUE) : POSITION_UNAVAILABLE_VALUE;
+		position.isXcoordValid ? MONRData.xPosition = (int32_t) (position.xCoord_m * POSITION_ONE_METER_VALUE) : MONRData.xPosition = POSITION_UNAVAILABLE_VALUE;
+		position.isYcoordValid ? MONRData.yPosition = (int32_t) (position.yCoord_m * POSITION_ONE_METER_VALUE) : MONRData.xPosition = POSITION_UNAVAILABLE_VALUE;
+		position.isZcoordValid ? MONRData.zPosition = (int32_t) (position.zCoord_m * POSITION_ONE_METER_VALUE) : MONRData.xPosition = POSITION_UNAVAILABLE_VALUE;
 	}
 	else {
 		errno = EINVAL;

--- a/iso22133.c
+++ b/iso22133.c
@@ -2758,9 +2758,9 @@ ssize_t encodeMONRMessage(const struct timeval *objectTime, const CartesianPosit
 	MONRData.gpsQmsOfWeek =
 		GPSQmsOfWeek >= 0 ? (uint32_t) GPSQmsOfWeek : GPS_SECOND_OF_WEEK_UNAVAILABLE_VALUE;
 	if (position.isPositionValid) {
-		position.isXcoordValid ? MONRData.xPosition = (int32_t) (position.xCoord_m * POSITION_ONE_METER_VALUE) : MONRData.xPosition = POSITION_UNAVAILABLE_VALUE;
-		position.isYcoordValid ? MONRData.yPosition = (int32_t) (position.yCoord_m * POSITION_ONE_METER_VALUE) : MONRData.xPosition = POSITION_UNAVAILABLE_VALUE;
-		position.isZcoordValid ? MONRData.zPosition = (int32_t) (position.zCoord_m * POSITION_ONE_METER_VALUE) : MONRData.xPosition = POSITION_UNAVAILABLE_VALUE;
+		MONRData.xPosition = position.isXcoordValid ? (int32_t) (position.xCoord_m * POSITION_ONE_METER_VALUE) : POSITION_UNAVAILABLE_VALUE;
+		MONRData.yPosition = position.isYcoordValid ?  (int32_t) (position.yCoord_m * POSITION_ONE_METER_VALUE) : POSITION_UNAVAILABLE_VALUE;
+		MONRData.zPosition = position.isZcoordValid ? (int32_t) (position.zCoord_m * POSITION_ONE_METER_VALUE) : POSITION_UNAVAILABLE_VALUE;
 	}
 	else {
 		errno = EINVAL;

--- a/iso22133.c
+++ b/iso22133.c
@@ -1734,7 +1734,7 @@ ssize_t encodeOSEMMessage(
 	OSEMData.date = objectSettings->isTimestampValid ?
 				(uint32_t) ((printableTime->tm_year + 1900) * 10000 + (printableTime->tm_mon + 1) * 100 +
 						   (printableTime->tm_mday))
-			  : DATE_UNAVAILABLE_VALUE;
+			  : DATE_UNAVAILABLE_VALUE; //Should OSEM be able to be sent without Date?
 
 	OSEMData.GPSWeekValueID = VALUE_ID_OSEM_GPS_WEEK;
 	OSEMData.GPSWeekContentLength = sizeof (OSEMData.GPSWeek);
@@ -2758,9 +2758,9 @@ ssize_t encodeMONRMessage(const struct timeval *objectTime, const CartesianPosit
 	MONRData.gpsQmsOfWeek =
 		GPSQmsOfWeek >= 0 ? (uint32_t) GPSQmsOfWeek : GPS_SECOND_OF_WEEK_UNAVAILABLE_VALUE;
 	if (position.isPositionValid) {
-		MONRData.xPosition = (int32_t) (position.xCoord_m * POSITION_ONE_METER_VALUE);
-		MONRData.yPosition = (int32_t) (position.yCoord_m * POSITION_ONE_METER_VALUE);
-		MONRData.zPosition = (int32_t) (position.zCoord_m * POSITION_ONE_METER_VALUE);
+		position.isXcoordValid ? MONRData.xPosition = (int32_t) (position.xCoord_m * POSITION_ONE_METER_VALUE) : POSITION_UNAVAILABLE_VALUE;
+		position.isYcoordValid ? MONRData.yPosition = (int32_t) (position.yCoord_m * POSITION_ONE_METER_VALUE) : POSITION_UNAVAILABLE_VALUE;
+		position.isZcoordValid ? MONRData.zPosition = (int32_t) (position.zCoord_m * POSITION_ONE_METER_VALUE) : POSITION_UNAVAILABLE_VALUE;
 	}
 	else {
 		errno = EINVAL;
@@ -3578,7 +3578,7 @@ ssize_t encodeMTSPMessage(const struct timeval *estSyncPointTime, char *mtspData
 	int64_t syncPtTime = getAsGPSQuarterMillisecondOfWeek(estSyncPointTime);
 
 	MTSPData.estSyncPointTime = estSyncPointTime == NULL || syncPtTime < 0 ?
-		GPS_SECOND_OF_WEEK_UNAVAILABLE_VALUE : (uint32_t) syncPtTime;
+		ESTIMATED_SYNC_POINT_TIME_UNAVAILABLE_VALUE : (uint32_t) syncPtTime;
 
 	if (debug) {
 		printf("MTSP message:\n\t"

--- a/positioning.h
+++ b/positioning.h
@@ -19,6 +19,9 @@ typedef struct {
 	double yCoord_m;
 	double zCoord_m;
 	double heading_rad;
+	bool isXcoordValid;
+	bool isYcoordValid;
+	bool isZcoordValid;
 	bool isPositionValid;
 	bool isHeadingValid;
 } CartesianPosition; // TODO: rename


### PR DESCRIPTION
This builds on the updated values and allows individual X,Y,Z offsets to be set as unavaliable in MONR. (Maybe Z is the only one that should be optional though)