### PR TITLE
Jenkins file for iso22133

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,10 +2,10 @@ pipeline {
   agent any
   stages {
     stage('Build') {
-      steps {
-        echo 'Test'
-      }
+			steps {
+				sh 'echo "Executing build steps..."'
+				cmakeBuild cleanBuild: true, buildDir: 'build', installation: 'InSearchPath', steps: [[envVars: 'DESTDIR=${WORKSPACE}/artifacts', withCmake: true]]
+			}
     }
-
   }
 }


### PR DESCRIPTION
Added a basic Jenkins file to iso22133 now that Jenkins is working again. Currently only runs Cmake and if there are no errors the the PR is considered to be correct as far as jenkins is concerned.

Tests can be added whenever we decide what we want to test and how, a template for a setup can be found in the Meastro Jenkins file.