### PR TITLE
Modified the TrajectoryWaypointType to use doubles in SI units

### DIFF
--- a/iso22133.h
+++ b/iso22133.h
@@ -58,15 +58,10 @@ typedef struct {
 
 /*! Trajectory WayPoint */
 typedef struct {
-	uint32_t relativeTime;
-	int32_t xPosition;
-	int32_t yPosition;
-	int32_t zPosition;
-	uint16_t heading;
-	int16_t longitudinalSpeed;
-	int16_t lateralSpeed;
-	int16_t longitudinalAcceleration;
-	int16_t lateralAcceleration;
+	struct timeval relativeTime;
+	CartesianPosition pos;
+	SpeedType spd;
+	AccelerationType acc;
 	float_t curvature;
 } TrajectoryWaypointType;
 


### PR DESCRIPTION
Manually optimizing for memory space is a tribute to history. @alfaro01 this will affect your dyno implementation - you'll need to remove the `* M_PI / 180.0` and such.