### PR TITLE
Tests for message size in headers

### DIFF
--- a/src/osem.c
+++ b/src/osem.c
@@ -53,10 +53,11 @@ ssize_t encodeOSEMMessage(
 
 	// Build header, and account for the two values which are 48 bit in the message
 	uint32_t msgLen = sizeof (HeaderType) + sizeof(OSEMIDType) + sizeof(OSEMOriginType)
-		- 2 * SizeDifference64bitTo48bit + sizeof (OSEMDateTimeType)
-		+ sizeof(OSEMAccuracyRequirementsType) + 4*2*sizeof(uint16_t) + sizeof (FooterType) 
-		+ timeServerUsed ? sizeof (OSEMTimeServerType) + 2*sizeof(uint16_t) : 0
-		+ idAssociationUsed ? sizeof(OSEMIDAssociationType) + 2*sizeof(uint16_t) : 0; // TODO handle id association
+		+ sizeof(OSEMDateTimeType) + sizeof(OSEMAccuracyRequirementsType)
+		+ 4*2*sizeof(uint16_t) + sizeof (FooterType);
+	msgLen -= 2 * SizeDifference64bitTo48bit;
+	msgLen += timeServerUsed ? sizeof (OSEMTimeServerType) + 2*sizeof(uint16_t) : 0;
+	msgLen += idAssociationUsed ? sizeof(OSEMIDAssociationType) + 2*sizeof(uint16_t) : 0; // TODO handle id association
 	OSEMData.header = buildISOHeader(MESSAGE_ID_OSEM, msgLen, debug);
 
 	// Fill the OSEM struct with relevant values

--- a/src/osem.c
+++ b/src/osem.c
@@ -1,10 +1,12 @@
 #include "osem.h"
 #include "defines.h"
 #include "timeconversions.h"
+#include "iso22133.h"
 
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
+
 
 /*!
  * \brief encodeOSEMMessage Creates an OSEM message and writes it into a buffer based on supplied values. All values are passed as pointers and

--- a/tests/monr.cpp
+++ b/tests/monr.cpp
@@ -69,6 +69,19 @@ protected:
 
 };
 
+TEST_F(EncodeMONR, MessageID)
+{
+	EXPECT_EQ(encodeBuffer[16], '\x06');
+	EXPECT_EQ(encodeBuffer[17], '\x00');
+}
+
+TEST_F(EncodeMONR, MessageLength)
+{
+	EXPECT_EQ(encodeBuffer[2], '\x28');
+	EXPECT_EQ(encodeBuffer[3], '\x00');
+	EXPECT_EQ(encodeBuffer[4], '\x00');
+	EXPECT_EQ(encodeBuffer[5], '\x00');
+}
 
 TEST_F(EncodeMONR, Preamble)
 {

--- a/tests/osem.cpp
+++ b/tests/osem.cpp
@@ -57,6 +57,20 @@ protected:
 	char* timeServer = accReq + 22; // skip accuracy requirements
 };
 
+TEST_F(EncodeOSEM, MessageID)
+{
+	EXPECT_EQ(encodeBuffer[16], '\x02');
+	EXPECT_EQ(encodeBuffer[17], '\x00');
+}
+
+TEST_F(EncodeOSEM, MessageLength)
+{
+	EXPECT_EQ(encodeBuffer[2], '\x56');
+	EXPECT_EQ(encodeBuffer[3], '\x00');
+	EXPECT_EQ(encodeBuffer[4], '\x00');
+	EXPECT_EQ(encodeBuffer[5], '\x00');
+}
+
 TEST_F(EncodeOSEM, IdStructPreamble)
 {
 	EXPECT_EQ(id[0], '\x20');

--- a/tests/traj.cpp
+++ b/tests/traj.cpp
@@ -29,6 +29,21 @@ protected:
 	char* name = info + 5;	// skip info
 };
 
+TEST_F(EncodeTRAJHeader, MessageID)
+{
+	EXPECT_EQ(encodeBuffer[16], '\x01');
+	EXPECT_EQ(encodeBuffer[17], '\x00');
+}
+
+TEST_F(EncodeTRAJHeader, MessageLength)
+{
+	// 68+6+5+21×(34)+5
+	EXPECT_EQ(encodeBuffer[2], '\x1E');
+	EXPECT_EQ(encodeBuffer[3], '\x03');
+	EXPECT_EQ(encodeBuffer[4], '\x00');
+	EXPECT_EQ(encodeBuffer[5], '\x00');
+}
+
 TEST_F(EncodeTRAJHeader, Id)
 {
 	EXPECT_EQ(id[0], '\x01');


### PR DESCRIPTION
Had a strange issue where a bunch of sizeof's summed up to a very small number. Added some tests to show this problem is gone.