### PR TITLE
Fix cmakepolicy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ FetchContent_MakeAvailable(googletest)
 set(ISO22133_TARGET ${TARGET_NAMESPACE}${PROJECT_NAME})
 
 include(GNUInstallDirs)
+# When building all packages in util top CMakeLists not only this lib we need to set this cmake policy to OLD due to target namespace are not unique in the same build tree in util
+# ref for info about the policy https://cmake.org/cmake/help/latest/policy/CMP0002.html 
 cmake_policy(SET CMP0002 OLD)
 
 file(GLOB SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/*.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,6 @@ set(ISO22133_TARGET ${TARGET_NAMESPACE}${PROJECT_NAME})
 include(GNUInstallDirs)
 cmake_policy(SET CMP0002 OLD)
 
-
 add_library(${ISO22133_TARGET} SHARED
         ${CMAKE_CURRENT_SOURCE_DIR}/positioning.c
         ${CMAKE_CURRENT_SOURCE_DIR}/iso22133.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ project(ISO22133 LANGUAGES C)
 set(ISO22133_TARGET ${TARGET_NAMESPACE}${PROJECT_NAME})
 
 include(GNUInstallDirs)
+cmake_policy(SET CMP0002 OLD)
+
 
 add_library(${ISO22133_TARGET} SHARED
         ${CMAKE_CURRENT_SOURCE_DIR}/positioning.c


### PR DESCRIPTION
Hi wounder if we could add set the cmakepolicy CMP0002 to old for now due to the fact that when building whole util separate we can't due to not having unique namespace in the util library. this is a cheap solution for now. Future work would be be to fix unique namespace in all util build tree